### PR TITLE
also symlink `init/modules/EESSI/2025.06.lua` + add `.modulerc` to hide `EESSI/2205.06` for now

### DIFF
--- a/roles/create_cvmfs_content_structure/files/EESSI-modulerc
+++ b/roles/create_cvmfs_content_structure/files/EESSI-modulerc
@@ -1,0 +1,2 @@
+-- hide EESSI/2025.06 module until software layer has enough installations in it
+hide_version("EESSI/2025.06")

--- a/roles/create_cvmfs_content_structure/vars/software.eessi.io.yml
+++ b/roles/create_cvmfs_content_structure/vars/software.eessi.io.yml
@@ -14,6 +14,11 @@ files:
     dest: ''
     mode: '644'
 
+  - name: EESSI-modulerc
+    dest: 'init/modules/EESSI/.modulerc'
+    mode: '644'
+
 symlinks:
   host_injections: '$(EESSI_HOST_INJECTIONS:-/opt/eessi)'
   init/modules/EESSI/2023.06.lua: /cvmfs/software.eessi.io/versions/2023.06/init/modules/EESSI/2023.06.lua
+  init/modules/EESSI/2025.06.lua: /cvmfs/software.eessi.io/versions/2025.06/init/modules/EESSI/2025.06.lua


### PR DESCRIPTION
@bedroge for https://github.com/EESSI/filesystem-layer/pull/198